### PR TITLE
downgrade python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: '3.12'
+        python-version: '3.10.0'
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.10.0'
     - name: Install Conda 23.5.2
       run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.2-Linux-x86_64.sh -O miniconda.sh
+        wget https://repo.anaconda.com/miniconda/Miniconda3-py310_25.1.1-2-Linux-x86_64.sh -O miniconda.sh
         bash miniconda.sh -b -p $HOME/miniconda
         echo "$HOME/miniconda/bin" >> $GITHUB_PATH
         source $HOME/miniconda/bin/activate      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10.0'
+        python-version: '3.11.0'
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.0'
+        python-version: '3.10.0'
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,8 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
-    - name: Downgrade conda to 24.9.1
-      run: |
-        conda install conda=24.9.1
+    - name: Install Specific Anaconda Version
+      run: conda install -n base conda=23.5.2
     - name: Install dependencies
       run: |
         conda env update --file environment.yml --name base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10.0'
     - name: Add conda to system path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
-    - name: Debug Conda Python Version
-      run: conda info && conda list python
+    - name: Install Python 3.10.0 in Conda
+      run: conda install -n base python=3.10.0
     - name: Install Specific Anaconda Version
       run: conda install -n base conda=23.5.2
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+    - name: Debug Conda Python Version
+      run: conda info && conda list python
     - name: Install Specific Anaconda Version
       run: conda install -n base conda=23.5.2
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.10.0'
     - name: Install Conda 23.5.2
       run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-py310_25.1.1-2-Linux-x86_64.sh -O miniconda.sh
+        wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O miniconda.sh
         bash miniconda.sh -b -p $HOME/miniconda
         echo "$HOME/miniconda/bin" >> $GITHUB_PATH
         source $HOME/miniconda/bin/activate      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.10.0'
-    - name: Add conda to system path
+    - name: Install Conda 23.5.2
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install Python 3.10.0 in Conda
-      run: conda install -n base python=3.10.0
-    - name: Install Specific Anaconda Version
-      run: conda install -n base conda=23.5.2
+        wget https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.2-Linux-x86_64.sh -O miniconda.sh
+        bash miniconda.sh -b -p $HOME/miniconda
+        echo "$HOME/miniconda/bin" >> $GITHUB_PATH
+        source $HOME/miniconda/bin/activate      
     - name: Install dependencies
       run: |
         conda env update --file environment.yml --name base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+    - name: Downgrade conda to 24.9.1
+      run: |
+        conda install conda=24.9.1
     - name: Install dependencies
       run: |
         conda env update --file environment.yml --name base

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: Stock_Price_Prediction
 dependencies:
-  - python=3.10.0
+  - python=3.11.0
   - pandas
   - numpy
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: Stock_Price_Prediction
 dependencies:
-  - python=3.11.0
+  - python=3.10.0
   - pandas
   - numpy
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: Stock_Price_Prediction
 dependencies:
-  - python=3.12
+  - python=3.10.0
   - pandas
   - numpy
   - scikit-learn


### PR DESCRIPTION
# This PR includes :
 - downgrading python version to 3.10.0 (from 3.12)
 - downgrading linux machine used in the pipeline version to 20.04
  - downgrading conda version to 23.5.2 (the one used in pipeline, you can use the one that works for you)
# Why ?
Azure-CLI has some compatibility issues with 3.12 and couldn't be installed 
More details : https://github.com/Azure/azure-cli/issues/27673

----------

Ps : when the PR is merged to main, please pull the latest version of main and execute the following commands
`conda deactivate`
`conda remove --name Stock_Price_Prediction --all -y`
`conda env create -f environment.yml`
`conda activate Stock_Price_Prediction`

this will ensure that all dependencies used are installed successfully (including azure-cli)