### PR TITLE
Upgrade py version from 3.10 -> 3.11 and ubuntu from 20.04 -> 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,21 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       max-parallel: 5
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10.0
+    - name: Set up Python 3.11.0
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10.0'
+        python-version: '3.11.0'
 
     - name: Install Conda 23.5.2
       run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O miniconda.sh
+        wget https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.2-0-Linux-x86_64.sh -O miniconda.sh
         bash miniconda.sh -b -p $HOME/miniconda
         echo "$HOME/miniconda/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -5,20 +5,20 @@ on:
 
 jobs:
   ETL:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Set Up Python 3.10
+    - name: Set Up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10.0"
+        python-version: "3.11.0"
 
     - name: Install Conda 23.5.2
       run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O miniconda.sh
+        wget https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.2-0-Linux-x86_64.sh -O miniconda.sh
         bash miniconda.sh -b -p $HOME/miniconda
         echo "$HOME/miniconda/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -9,20 +9,20 @@ on:
 
 jobs:
   train-model:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Set Up Python 3.10
+      - name: Set Up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10.0"
+          python-version: "3.11.0"
 
       - name: Install Conda 23.5.2
         run: |
-          wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O miniconda.sh
+          wget https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.2-0-Linux-x86_64.sh -O miniconda.sh
           bash miniconda.sh -b -p $HOME/miniconda
           echo "$HOME/miniconda/bin" >> $GITHUB_PATH
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: Stock_Price_Prediction
 dependencies:
-  - python=3.10.0
+  - python=3.11.0
   - pandas
   - numpy
   - scikit-learn


### PR DESCRIPTION
# This PR includes 
 - Bumping python version to 3.11 and ubuntu to 24.04
 
 # Why ?
  - As of 15-04-2025, ubuntu 20.04 (the version used in our pipelines) is deprecated and no longer in use, for more details check https://github.com/actions/runner-images/issues/11101
  - the ubuntu 20.04 is the newest version supporting python 3.10 => py 3.10 was no longer testable on ubuntu machines so we needed to upgrade to python 3.11