### PR TITLE
Add training script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,8 @@ BACKEND_URL= xxx
 FRONTEND_URL= xxx
 
 # frontend cache
-FRONTEND_CACHE_EXPIRATION_TIME= xx
+FRONTEND_CACHE_EXPIRATION_TIME= xxx
+
+# model training
+MODEL_NAME= xxx
+WINDOW_SIZE= xxx

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -6,6 +6,7 @@ on:
       - data/processed/**  # Trigger when processed data is updated
     branches:
       - main
+  workflow_dispatch:
 
 env:
   KERAS_BACKEND: ${{ vars.KERAS_BACKEND }}

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+env:
+  KERAS_BACKEND: ${{ vars.KERAS_BACKEND }}
+  MODEL_NAME: ${{ vars.MODEL_NAME }}
+  WINDOW_SIZE: ${{ vars.WINDOW_SIZE }}
+
 jobs:
   train-model:
     runs-on: ubuntu-24.04
@@ -60,4 +65,5 @@ jobs:
           echo "PYTHONPATH: $PYTHONPATH"
 
           # Run the training script
-          echo "Training model on Azure ML (To be implemented)"
+          echo "Training model on Azure ML"
+          python -m scripts.train_model

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import pandas as pd
+from dotenv import load_dotenv
+import logging
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(os.getcwd()) / '..'))
+from src.handlers.model_handler import get_or_create_model, save_model
+from src.handlers.scaler_handler import get_or_create_scaler, save_scaler
+from utils.train_test_utils import train_model
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def train():
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "../data/processed")
+    DATA_DIR = os.path.abspath(DATA_DIR)
+
+    load_dotenv()
+
+    WINDOW_SIZE = int(os.environ.get("WINDOW_SIZE")) 
+    MODEL_NAME = os.environ.get("MODEL_NAME")
+
+    stocks_list = [f.replace(".csv.dvc", "") for f in os.listdir(DATA_DIR) if f.endswith(".csv.dvc")]
+    logger.info(f"found {len(stocks_list)} stocks")
+    for stock in stocks_list:
+        logger.info(f"training model: {MODEL_NAME} for stock: {stock}")
+        dvc_file = os.path.join(DATA_DIR, f"{stock}.csv.dvc")
+        csv_file = dvc_file.replace(".dvc", "")
+        if not os.path.exists(csv_file):
+            logger.info("pulling csv files")
+            subprocess.run(["dvc", "pull", dvc_file], check=True, capture_output=True, text=True)
+        if not os.path.exists(csv_file):
+            logger.warning(f"{stock}.csv not found")
+            continue
+        df = pd.read_csv(csv_file, sep=";")
+        model = get_or_create_model(stock, MODEL_NAME)
+        scaler = get_or_create_scaler(stock)
+        last_trained_date = model.get_last_trained_date()
+        logger.info(f"model's old last trained date: {last_trained_date if last_trained_date else 'Never trained before'}")
+        df["date"] = pd.to_datetime(df["date"])
+        if last_trained_date:
+            num_train_rows = len(df[df['date'] > last_trained_date])
+        else:
+            num_train_rows = len(df["date"]) - WINDOW_SIZE
+        if num_train_rows == 0:
+            logger.warning("No new rows to train ...")
+            continue
+        logger.info(f"Found {num_train_rows} rows to train the model with")
+        new_last_trained_date = max(df["date"])
+        logger.info(f"model's new last trained date: {new_last_trained_date}")
+        if last_trained_date:
+            train_df = df.tail(WINDOW_SIZE + num_train_rows).copy()
+        else:
+            train_df = df.copy()
+        train_df = train_df["cloture"].values.reshape(-1,1)
+        full_model_name = f"{MODEL_NAME} {stock}"
+        scaler = train_model(model, full_model_name, train_df, scaler, WINDOW_SIZE, new_last_trained_date)
+        logger.info(f"Training {stock} model done, saving model and scaler")
+        save_model(model)
+        save_scaler(scaler)
+    logger.info("Training script completed successfully")
+
+if __name__ == "__main__":
+    # Run the processing pipeline
+    train()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,4 @@
 from .web import CacheService
 from .prediction_model import IModel, ARIMAModel, LSTMModel, GRUModel
+from .factories import create_model
+from .handlers import get_or_create_scaler, get_or_create_model, save_scaler, save_model

--- a/src/factories/__init__.py
+++ b/src/factories/__init__.py
@@ -1,0 +1,1 @@
+from .model_factory import create_model

--- a/src/factories/model_factory.py
+++ b/src/factories/model_factory.py
@@ -1,0 +1,17 @@
+from src.prediction_model.models import IModel, ARIMAModel, LSTMModel, GRUModel
+from dotenv import load_dotenv
+
+load_dotenv()
+
+def create_model(stock: str, model_name: str) -> IModel:
+    if model_name is None:
+        raise KeyError("The model name is not specified in the environment file!")
+    match model_name:
+        case "ARIMA":
+            return ARIMAModel(stock)
+        case "GRU":
+            return GRUModel(stock)
+        case "LSTM":
+            return LSTMModel(stock)
+        case _:
+            return NotImplementedError("The given model name is not implemented yet, please choose another one!")

--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -1,0 +1,2 @@
+from .model_handler import get_or_create_model, save_model
+from .scaler_handler import get_or_create_scaler, save_scaler

--- a/src/handlers/model_handler.py
+++ b/src/handlers/model_handler.py
@@ -1,0 +1,9 @@
+from src.prediction_model.models import IModel
+from src.factories.model_factory import create_model
+
+def get_or_create_model(stock: str, model_name: str) -> IModel:
+    # TODO: Check first if the model exists already in azure ML, if so bring it
+    return create_model(stock, model_name)
+
+def save_model(model: IModel):
+    raise NotImplementedError("Method not implemented!")

--- a/src/handlers/scaler_handler.py
+++ b/src/handlers/scaler_handler.py
@@ -1,0 +1,8 @@
+from sklearn.preprocessing import MinMaxScaler
+
+def get_or_create_scaler(stock: str):
+    # TODO: Check first if the scaler exists already in azure ML, if so bring it
+    return MinMaxScaler()
+
+def save_scaler(scaler: MinMaxScaler):
+    raise NotImplementedError("This method isn't implemented!")

--- a/src/prediction_model/models/ARIMAModel.py
+++ b/src/prediction_model/models/ARIMAModel.py
@@ -3,16 +3,18 @@ from statsmodels.tsa.arima.model import ARIMA
 from .IModel import IModel
 
 class ARIMAModel(IModel):
-    def __init__(self):
+    def __init__(self, stock_name: str = None):
+        super().__init__(stock_name)
         pass
     
-    def train(self, features, targets):
+    def train(self, features, targets, last_trained_date):
         # for ARIMA model there isn't a separation between features and targets so we pass all the data in the features param
         features = features.flatten()
         print(f"features shape: {features.shape}")
         model = ARIMA(features, order=(2,1,5)) # the order was found when running auto_arima method which generated the best orders
         model_fit = model.fit()
         self.model = model_fit
+        self.__last_trained_date = max(last_trained_date, self.__last_trained_date)
     
     def predict(self, input_data):
         numberOfDays = len(input_data)

--- a/src/prediction_model/models/GRUModel.py
+++ b/src/prediction_model/models/GRUModel.py
@@ -1,9 +1,9 @@
 from .IModel import IModel
 from keras.src.models import Sequential
 from keras.src.layers import GRU, Dense, Dropout
-
 class GRUModel(IModel):
-    def __init__(self):
+    def __init__(self, stock_name: str = None):
+        super().__init__(stock_name)
         model = Sequential()
         model.add(GRU(50))
         model.add(Dropout(0.2))
@@ -12,10 +12,11 @@ class GRUModel(IModel):
         model.compile(optimizer='adam', loss='mean_squared_error')
         self.model = model
 
-    def train(self, features, targets):
+    def train(self, features, targets, last_trained_date):
         print(f"features shape: {features.shape}")
         print(f"targets shape: {targets.shape}")
         self.model.fit(x=features, y=targets, batch_size=32, epochs=40, verbose=1)
+        self.__last_trained_date = max(last_trained_date, self.__last_trained_date)
     
     def predict(self, input_data):
         print(f"input shape: {input_data.shape}")

--- a/src/prediction_model/models/IModel.py
+++ b/src/prediction_model/models/IModel.py
@@ -1,16 +1,20 @@
 from abc import ABC, abstractmethod
 import numpy as np
 from enums import ValidationMetricEnum
-from sklearn.preprocessing import MinMaxScaler
+from datetime import datetime
 
 class IModel(ABC):
     """
     Abstract base class for a prediction model.
     This class defines the interface that all prediction models must implement.
     """
+    @abstractmethod
+    def __init__(self, stock_name: str = None):
+        self.__last_trained_date = None
+        self.__stock_name = stock_name
 
     @abstractmethod
-    def train(self, features: np.ndarray, targets: np.ndarray):
+    def train(self, features: np.ndarray, targets: np.ndarray, last_trained_date: datetime):
         """
         Train the model using the provided data.
 
@@ -67,3 +71,9 @@ class IModel(ABC):
                 return mape
             case _:
                 raise NotImplementedError("This metric isn't implemented yet, if you want to use it please add its implementation")
+    
+    def get_last_trained_date(self) -> datetime:
+        return self.__last_trained_date
+
+    def get_stock_name(self) -> str:
+        return self.__stock_name

--- a/src/prediction_model/models/LSTMModel.py
+++ b/src/prediction_model/models/LSTMModel.py
@@ -3,7 +3,8 @@ from keras.src.models import Sequential
 from keras.src.layers import LSTM, Dense, Dropout
 
 class LSTMModel(IModel):
-    def __init__(self):
+    def __init__(self, stock_name: str = None):
+        super().__init__(stock_name)
         model = Sequential()
         model.add(LSTM(50, return_sequences=True))
         model.add(Dropout(0.2))
@@ -14,10 +15,11 @@ class LSTMModel(IModel):
         model.compile(optimizer='adam', loss='mean_squared_error')
         self.model = model
 
-    def train(self, features, targets):
+    def train(self, features, targets, last_trained_date):
         print(f"features shape: {features.shape}")
         print(f"targets shape: {targets.shape}")
         self.model.fit(x=features, y=targets, batch_size=32, epochs=40, verbose=1)
+        self.__last_trained_date = max(last_trained_date, self.__last_trained_date)
     
     def predict(self, input_data):
         print(f"input shape: {input_data.shape}")

--- a/tests/scripts/test_train_model.py
+++ b/tests/scripts/test_train_model.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch, MagicMock, mock_open
+import os
+import pandas as pd
+import numpy as np
+
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@patch("builtins.open", new_callable=mock_open)
+@patch("os.path.exists")
+@patch("os.listdir")
+@patch("os.path.join", side_effect=lambda *args: "/".join(args))
+@patch("subprocess.run")
+@patch("pandas.read_csv")
+@patch("src.handlers.model_handler.get_or_create_model")
+@patch("src.handlers.model_handler.save_model")
+@patch("src.handlers.scaler_handler.get_or_create_scaler")
+@patch("src.handlers.scaler_handler.save_scaler")
+@patch("utils.train_test_utils.train_model")
+@patch("dotenv.load_dotenv")
+@patch.dict(os.environ, {"WINDOW_SIZE": "5", "MODEL_NAME": "LSTM"})
+def test_train_function(
+    mock_dotenv, mock_train_model, mock_save_scaler, mock_get_scaler,
+    mock_save_model, mock_get_model, mock_read_csv, mock_subprocess_run,
+    mock_join, mock_listdir, mock_exists, mock_open_file
+):
+    from scripts.train_model import train
+
+    mock_listdir.return_value = ["AAPL.csv.dvc"]
+    mock_exists.side_effect = lambda path: not path.endswith(".dvc")
+
+    df = pd.DataFrame({
+        "date": pd.date_range(start="2020-01-01", periods=20),
+        "cloture": np.random.rand(20)
+    })
+    mock_read_csv.return_value = df
+
+    dummy_model = MagicMock()
+    dummy_model.get_last_trained_date.return_value = pd.to_datetime("2020-01-10")
+    mock_get_model.return_value = dummy_model
+
+    dummy_scaler = MagicMock()
+    mock_get_scaler.return_value = dummy_scaler
+    mock_train_model.return_value = dummy_scaler
+
+    # --- Call the function ---
+    train()
+
+    # --- Assertions ---
+    mock_dotenv.assert_called()
+    mock_read_csv.assert_called_once()
+    mock_get_model.assert_called_once_with("AAPL", "LSTM")
+    mock_train_model.assert_called_once()
+    mock_save_model.assert_called_once()
+    mock_save_scaler.assert_called_once()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,2 @@
 from .constants import HEADERS, SYMBOLS, RAW_DATA_DOWNLOAD_BASELINK
-from .train_test_utils import split_dataset, get_features_target_from_dataset, train, evaluate, plot_evaluation_result, plot_stock_graph
+from .train_test_utils import split_dataset, get_features_target_from_dataset, train, evaluate, plot_evaluation_result, plot_stock_graph, train_model, predict


### PR DESCRIPTION
# This PR includes:
 - Adding a script to train the models to be used in a cron job later
 - Add some utilities functions / modules to be used later / in the script
 - updated the .env.example and the train pipeline accordingly


This script and the solution in general was designed in a way that it would solely depend on the environment (only the script does, the utility methods don't). i.e if I for some reason want to no longer use LSTM and use another model instead (as long as the model is implemented and uses the same data as the LSTM) we would only need to change the env var MODEL_NAME and delete the azure ml model and run the pipeline manually : WE WONT NEED TO DO ANY CODE CHANGES WHATSOEVER (the same applies to the window size)
 
# What does the script do exactly (for each stock):
 - We fetch the csv file if existing
 - We get the model / scaler (for now we just instantiate them and later on we will integrate azure ML)
 - Get the model's last trained date (a new property added to the IModel abstract class) , this date corresponds to the date of the latest row on which the model was trained
 - if the date exists we check for rows with later dates and only use them for training, else we use the whole dataset to train the model and fit the scaler
 - after training we save the model and scaler (not implemented yet)
 
# What's left:
 - Implement the Azure ML integration part cc @ramirachdi 
 - potentially add mechanisms to check for regressions in model accuracy and send alerts